### PR TITLE
Added a POST method that returns only a string.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: bgmulinari

--- a/B1SLayer/SLRequest.cs
+++ b/B1SLayer/SLRequest.cs
@@ -281,7 +281,7 @@ namespace B1SLayer
         /// <summary>
         /// Performs a POST request without parameters and returns the result in a <see cref="string"/>.
         /// </summary>
-        public async Task<string> PostStringAsync()
+        public async Task<string> PostReceiveStringAsync()
         {
             return await _slConnection.ExecuteRequest(async () =>
             {

--- a/B1SLayer/SLRequest.cs
+++ b/B1SLayer/SLRequest.cs
@@ -279,6 +279,17 @@ namespace B1SLayer
         }
 
         /// <summary>
+        /// Performs a POST request without parameters and returns the result in a <see cref="string"/>.
+        /// </summary>
+        public async Task<string> PostStringAsync()
+        {
+            return await _slConnection.ExecuteRequest(async () =>
+            {
+                return await FlurlRequest.WithCookies(_slConnection.Cookies).PostAsync().ReceiveString();
+            });
+        }
+
+        /// <summary>
         /// Performs a POST request with the provided parameters.
         /// </summary>
         /// <param name="data">


### PR DESCRIPTION
Added a POST method that returns only a string. It's usefull when you are using a service like 'SBOBobService_GetSystemCurrency'. This service just returns a string, while the default PostStringAsync  (<data>) make a json convertion that returns an exception.