### PR TITLE
 Add batch header mirroring functionality for multipart responses

### DIFF
--- a/B1SLayer.Test/Tests/SLBatchRequestTests.cs
+++ b/B1SLayer.Test/Tests/SLBatchRequestTests.cs
@@ -11,8 +11,9 @@ public class SLBatchRequestTests : TestBase
     private const string
         expectedRequestBody = "*--*-*-*-*-*Content-Type: multipart/mixed; boundary=\"changeset_*-*-*-*-*\"*--changeset_*-*-*-*-*Content-Type: application/http; msgtype=request*content-transfer-encoding: binary*Content-ID: 1*POST /b1s/v*/BusinessPartners HTTP/1.1*Host: *:50000*Content-Type: application/json; charset=utf-8*{\"CardCode\":\"C00001\",\"CardName\":\"I am a new BP\"}*--changeset_*-*-*-*-*Content-Type: application/http; msgtype=request*content-transfer-encoding: binary*Content-ID: 2*PATCH /b1s/v*/BusinessPartners('C00001') HTTP/1.1*Host: *:50000*Content-Type: application/json; charset=utf-8*{\"CardName\":\"This is my updated name\"}*--changeset_*-*-*-*-*Content-Type: application/http; msgtype=request*content-transfer-encoding: binary*Content-ID: 3*DELETE /b1s/v*/BusinessPartners('C00001') HTTP/1.1*Host: *:50000*--changeset_*-*-*-*-*--*--*-*-*-*-*--*",
         v1Response = "--batchresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: multipart/mixed; boundary=changesetresponse_00000000-0000-0000-0000-000000000000\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 201 Created\r\nContent-ID: 1\r\nContent-Type: application/json;odata=minimalmetadata;charset=utf-8\r\nContent-Length: 8811\r\nDataServiceVersion: 3.0\r\nETag: W/\"0000000000000000000000000000000000000000\"\r\nLocation: https://localhost:50000/b1s/v1/BusinessPartners('C00001')\r\n\r\n{\"some\":\"content\"}\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nContent-ID: 2\r\nDataServiceVersion: 3.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 204 No Content\r\nContent-ID: 3\r\nDataServiceVersion: 3.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000--\r\n--batchresponse_00000000-0000-0000-0000-000000000000--\r\n",
-        v2Response = "--batchresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: multipart/mixed; boundary=changesetresponse_00000000-0000-0000-0000-000000000000\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: application/json;odata.metadata=minimal;charset=utf-8\r\nContent-Length: 8811\r\nETag: W/\"0000000000000000000000000000000000000000\"\r\nLocation: https://localhost:50000/b1s/v2/BusinessPartners('C00001')\r\nOData-Version: 4.0\r\n\r\n{\"some\":\"content\"}\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nHTTP/1.1 204 No Content\r\nOData-Version: 4.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nHTTP/1.1 204 No Content\r\nOData-Version: 4.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000--\r\n--batchresponse_00000000-0000-0000-0000-000000000000--\r\n";
-
+        v2Response = "--batchresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: multipart/mixed; boundary=changesetresponse_00000000-0000-0000-0000-000000000000\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 1\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: application/json;odata.metadata=minimal;charset=utf-8\r\nContent-Length: 8811\r\nETag: W/\"0000000000000000000000000000000000000000\"\r\nLocation: https://localhost:50000/b1s/v2/BusinessPartners('C00001')\r\nOData-Version: 4.0\r\n\r\n{\"some\":\"content\"}\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 2\r\n\r\nHTTP/1.1 204 No Content\r\nOData-Version: 4.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nHTTP/1.1 204 No Content\r\nOData-Version: 4.0\r\n\r\n\r\n--changesetresponse_00000000-0000-0000-0000-000000000000--\r\n--batchresponse_00000000-0000-0000-0000-000000000000--\r\n",
+        v2ResponseError = "--batchresponse_00000000-0000-0000-0000-000000000000\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\nContent-ID: 3\r\n\r\nHTTP/1.1 400 Bad Request\r\nContent-Type: application/json;charset=utf-8\r\nContent-Length: 82\r\nOData-Version: 4.0\r\n\r\n{\r\n   \"error\" : {\r\n      \"code\" : \"-1109\",\r\n      \"message\" : \"Unknown error\"\r\n   }\r\n}\r\n--batchresponse_00000000-0000-0000-0000-000000000000--\r\n";
+    
     private static readonly SLBatchRequest[] _requests =
     [
         new SLBatchRequest(HttpMethod.Post, "BusinessPartners", new { CardCode = "C00001", CardName = "I am a new BP" }, 1),
@@ -62,5 +63,32 @@ public class SLBatchRequestTests : TestBase
         Assert.Equal(HttpStatusCode.NoContent, batchResult[1].StatusCode);
         Assert.Equal(HttpStatusCode.NoContent, batchResult[2].StatusCode);
         Assert.Equal("{\"some\":\"content\"}", await batchResult[0].Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task PostBatchAsyncV2_ReturnsErrorResponseWithMirroredBatchHeaders()
+    {
+        HttpTest.RespondWith(
+            body: v2ResponseError,
+            status: 200,
+            headers: new Dictionary<string, string> { { "Content-Type", "multipart/mixed;boundary=batchresponse_00000000-0000-0000-0000-000000000000" } });
+
+        var batchResult = await SLConnectionV2.PostBatchAsync(_requests);
+
+        HttpTest.ShouldHaveCalled(SLConnectionV2.ServiceLayerRoot.AppendPathSegment("$batch"))
+            .WithVerb(HttpMethod.Post)
+            .WithRequestMultipart(call => FileSystemName.MatchesSimpleExpression(expectedRequestBody, call.Content))
+            .Times(1);
+
+        Assert.Single(batchResult);
+        Assert.Equal(HttpStatusCode.BadRequest, batchResult[0].StatusCode);
+        
+        // Verify that batch headers were mirrored as X-BatchHeader-*
+        Assert.True(batchResult[0].Headers.Contains("X-BatchHeader-Content-Type"));
+        Assert.Equal("application/http", batchResult[0].Headers.GetValues("X-BatchHeader-Content-Type").First());
+        Assert.True(batchResult[0].Headers.Contains("X-BatchHeader-Content-Transfer-Encoding"));
+        Assert.Equal("binary", batchResult[0].Headers.GetValues("X-BatchHeader-Content-Transfer-Encoding").First());
+        Assert.True(batchResult[0].Headers.Contains("X-BatchHeader-Content-ID"));
+        Assert.Equal("3", batchResult[0].Headers.GetValues("X-BatchHeader-Content-ID").First());
     }
 }


### PR DESCRIPTION
## Summary
  - Add functionality to mirror batch headers as `X-BatchHeader-*` headers in multipart responses
  - Improve debugging and traceability by preserving original batch response headers
  - Add comprehensive unit tests for the new functionality

  ## Changes
  - **MultipartHelper.cs**: Extract batch headers from multipart responses and mirror them as `X-BatchHeader-*` headers in each inner response
  - **SLBatchRequestTests.cs**: Add new test case `PostBatchAsyncV2_ReturnsErrorResponseWithMirroredBatchHeaders` to verify header mirroring works correctly for error responses

  ## Technical Details
  The implementation extracts headers from the batch response boundary section and adds them to individual response messages with the `X-BatchHeader-` prefix. This allows consumers to access original batch-level metadata that would otherwise be lost when parsing multipart responses.

  ## Future Considerations
  This approach was chosen to maintain backward compatibility. A more elegant solution would be to introduce a dedicated `BatchResponse` type that properly encapsulates batch-level headers alongside individual responses. However, this would constitute a breaking change and is being considered for a future
  major version.

  The current header mirroring approach provides immediate value while preserving API compatibility.

  ## Test Plan
  - [x] Unit tests pass for header mirroring functionality
  - [x] Existing batch request functionality remains unchanged
  - [x] Error response scenarios properly mirror batch headers

  ## Breaking Changes
  None - this is a backward-compatible enhancement that adds new headers without modifying existing behavior.