### PR TITLE
Fix: NullReferenceException (Object reference not set to an instance of an object.) when parsing batch responses on .NET Framework

### DIFF
--- a/B1SLayer/MultipartHelper.cs
+++ b/B1SLayer/MultipartHelper.cs
@@ -33,7 +33,10 @@ internal static class MultipartHelper
             var requestData = part.Split(new[] { "\n\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             requestData = requestData.Where(x => !x.StartsWith("--") && !x.StartsWith("\r\n")).ToArray();
             var headers = requestData[0].Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).Skip(1);
-            var httpResponse = new HttpResponseMessage();
+            var httpResponse = new HttpResponseMessage 
+            {
+                Content = new StringContent(string.Empty)
+            };
             httpResponse.Version = new Version(part.Substring(0, 3));
             httpResponse.StatusCode = (HttpStatusCode)int.Parse(part.Substring(4, 3));
 


### PR DESCRIPTION
Hi,
First of all, thanks for this great library! It's helping me a lot.
I've encountered a runtime issue when using `PostBatchAsync` from a .NET Framework 4.8 application. 
**The problem is triggered specifically when the batch contains a `PATCH` operation.**
The operation succeeds on the SAP side, but a `NullReferenceException` is thrown inside `MultipartHelper.ReadMultipartResponseAsync` when parsing the response.

The problem is a subtle difference in the `HttpResponseMessage` constructor's behavior:
* On **.NET Framework 4.8**, `new HttpResponseMessage().Content` is `null` by default.

When a response part has no body (like a successful `PATCH` returning `HTTP 204 No Content`), the code attempts to access properties on a `null` `Content` object, causing the crash.

**The Fix**

This PR fixes the issue by explicitly initializing the `HttpResponseMessage` object with an empty `StringContent`, like this:

```csharp
var httpResponse = new HttpResponseMessage 
{
    Content = new StringContent(string.Empty)
};
```
This should improve compatibility for users on older runtimes without affecting the experience on modern .NET.

Thanks for your consideration!